### PR TITLE
Explicitly set content type on xhr request

### DIFF
--- a/src/anki.ts
+++ b/src/anki.ts
@@ -34,6 +34,7 @@ export function invoke(action: string, params={}) {
         });
 
         xhr.open('POST', 'http://127.0.0.1:' + ANKI_PORT.toString());
+        xhr.setRequestHeader('Content-Type', 'application/json');
         xhr.send(JSON.stringify({action, version: 6, params}));
     });
 }


### PR DESCRIPTION
As a user I had to introduce a proxy between the plugin and Anki actual program to work around issues with Snap packaging (Having Obsidian installed as a snap package).

That proxy used to set default headers on the request and caused it to be processed incorrectly. This line prevented that for the content type header.

It's important because when AnkiConnect does not recognize the content type it returns something like "AnkiConnect v.6" which cause the connection to fail.